### PR TITLE
Always transform assetUrl into explicitly ?url imports

### DIFF
--- a/fixtures/asseturl-use-file-name/output.js
+++ b/fixtures/asseturl-use-file-name/output.js
@@ -1,7 +1,7 @@
-import $_asseturl___styles_css3 from "./styles.css?inline";
-import $_asseturl___foo_bar_jpg2 from "./foo@bar.jpg";
-import $_asseturl___foo_jpg0 from "./foo.jpg";
-import $_asseturl___foo_bar_jpg1 from "./foo-bar.jpg";
+import $_asseturl___styles_css3 from "./styles.css?url";
+import $_asseturl___foo_bar_jpg2 from "./foo@bar.jpg?url";
+import $_asseturl___foo_jpg0 from "./foo.jpg?url";
+import $_asseturl___foo_bar_jpg1 from "./foo-bar.jpg?url";
 import { assetUrl } from "fusion-core";
 const Test = $_asseturl___foo_jpg0;
 const Test2 = $_asseturl___foo_bar_jpg1;

--- a/fixtures/asseturl-use-namespace/output.js
+++ b/fixtures/asseturl-use-namespace/output.js
@@ -1,8 +1,8 @@
-import $_asseturl___src_e_jpg4 from "./src/e.jpg";
-import $_asseturl___d_png3 from "./d.png";
-import $_asseturl___c_gif2 from "./c.gif";
-import $_asseturl___b_jpg1 from "./b.jpg";
-import $_asseturl___a_png0 from "./a.png";
+import $_asseturl___src_e_jpg4 from "./src/e.jpg?url";
+import $_asseturl___d_png3 from "./d.png?url";
+import $_asseturl___c_gif2 from "./c.gif?url";
+import $_asseturl___b_jpg1 from "./b.jpg?url";
+import $_asseturl___a_png0 from "./a.png?url";
 import { assetUrl as testUrl } from "fusion-core";
 const a = $_asseturl___a_png0;
 const b = $_asseturl___b_jpg1;

--- a/packages/fusion/transform/src/visitors/asseturl.rs
+++ b/packages/fusion/transform/src/visitors/asseturl.rs
@@ -95,11 +95,7 @@ impl VisitMut for AsseturlVisitor {
             });
 
             let initial_src_value: String = i.file_path.clone().into();
-            let src_value = if initial_src_value.ends_with(".css") {
-                format!("{}?inline", initial_src_value)
-            } else {
-                initial_src_value
-            };
+            let src_value = format!("{}?url", initial_src_value);
 
             prepend_stmt(
                 &mut n.body,


### PR DESCRIPTION
Vite only treats a specific subset of file extensions as URL imports (https://vitejs.dev/config/shared-options.html#assetsinclude)

However, `assetUrl()` should always produce a URL