### PR TITLE
Ensure generated paths in split() matches JS

### DIFF
--- a/fixtures/split-no-ssr/output.js
+++ b/fixtures/split-no-ssr/output.js
@@ -3,6 +3,6 @@ Object.defineProperties(import("./foo/baz"), {
         value: []
     },
     __MODULE_ID: {
-        value: "virtual:fusion-vite-split-loader?importer=%2Fpath%2Fto%2Ffile%2Ejs&specifier=%2E%2Ffoo%2Fbaz"
+        value: "virtual:fusion-vite-split-loader?importer=%2Fpath%2Fto%2Ffile.js&specifier=.%2Ffoo%2Fbaz"
     },
 });

--- a/fixtures/split/output.js
+++ b/fixtures/split/output.js
@@ -3,12 +3,12 @@ Object.defineProperties(import("./foo/baz"), {
         value: []
     },
     __MODULE_ID: {
-        value: "virtual:fusion-vite-split-loader?importer=%2Fpath%2Fto%2Ffile%2Ejs&specifier=%2E%2Ffoo%2Fbaz"
+        value: "virtual:fusion-vite-split-loader?importer=%2Fpath%2Fto%2Ffile.js&specifier=.%2Ffoo%2Fbaz"
     },
     __FUSION_DYNAMIC_IMPORT_METADATA__: {
         value: {
             version: 0,
-            moduleId: "virtual:fusion-vite-split-loader?importer=%2Fpath%2Fto%2Ffile%2Ejs&specifier=%2E%2Ffoo%2Fbaz"
+            moduleId: "virtual:fusion-vite-split-loader?importer=%2Fpath%2Fto%2Ffile.js&specifier=.%2Ffoo%2Fbaz"
         }
     }
 });

--- a/packages/fusion-js-test/fixture.js
+++ b/packages/fusion-js-test/fixture.js
@@ -59,7 +59,7 @@ const run = async () => {
       let result = (
         await transform(code, {
           isModule: true,
-          filename: "code.js",
+          filename: "/path/to/file.js",
           jsc: {
             target: "esnext",
             experimental: {
@@ -81,15 +81,6 @@ const run = async () => {
           },
         })
       ).code;
-      // manually fixing some differences caused by __dirname and __filename being different
-      // in the test environment
-      result = result
-        .replace(
-          `console.log(""); // __dirname`,
-          `console.log("/path/to"); // __dirname`
-        )
-        .replace(/code%2Ejs/g, "%2Fpath%2Fto%2Ffile%2Ejs")
-        .replace(/code\.js/g, "/path/to/file.js");
       result = await format(result, { parser: "babel" });
 
       if (result != output) {


### PR DESCRIPTION
The existing implementation percent encodes different characters than [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) from JS, which can lead to incompatibility with code generated from JS.

Updates the set of encoded character to match WHATWG spec: https://url.spec.whatwg.org/#component-percent-encode-set