### PR TITLE
Fix edge case with i18n HOC

### DIFF
--- a/fixtures/i18n-with-translations/code.js
+++ b/fixtures/i18n-with-translations/code.js
@@ -7,3 +7,9 @@ export default withTranslations(['test', 'foo'])(({ translate }) => {
 export const Baz = compose(withReducer(baz), withTranslations(['bar'])(({ translate }) => {
   return <input placeholder={translate('bar')} />;
 }));
+
+export const Qux = compose(
+  withTranslations([
+    'qux',
+  ])
+)(Q);

--- a/fixtures/i18n-with-translations/output.js
+++ b/fixtures/i18n-with-translations/output.js
@@ -1,22 +1,26 @@
 import _fusionPluginI18nChunkTranslationMap from "virtual:fusion-vite-i18n-map";
 import { withTranslations } from 'fusion-plugin-i18n-react';
 export default withTranslations([
-  'test',
-  'foo'
-])(({ translate }) => {
-  return <input placeholder={translate('test', {
-    name: 'world'
-  })} />;
+    'test',
+    'foo'
+])(({ translate })=>{
+    return <input placeholder={translate('test', {
+        name: 'world'
+    })}/>;
 });
 export const Baz = compose(withReducer(baz), withTranslations([
-  'bar'
-])(({ translate }) => {
-  return <input placeholder={translate('bar')} />;
+    'bar'
+])(({ translate })=>{
+    return <input placeholder={translate('bar')}/>;
 }));
+export const Qux = compose(withTranslations([
+    'qux'
+]))(Q);
 _fusionPluginI18nChunkTranslationMap.add("/path/to/file.js", [
-  "vite-i18n-chunk"
+    "vite-i18n-chunk"
 ], [
-  "bar",
-  "foo",
-  "test"
+    "bar",
+    "foo",
+    "qux",
+    "test"
 ]);

--- a/packages/fusion/transform/src/i18n/analyze_imports.rs
+++ b/packages/fusion/transform/src/i18n/analyze_imports.rs
@@ -188,43 +188,37 @@ impl Visit for Analyzer<'_> {
                          translation keys.";
         match &call_expr.callee {
             Callee::Expr(boxed_expr) => match &**boxed_expr {
-                Expr::Call(inner_call_expr) => match &inner_call_expr.callee {
-                    Callee::Expr(inner_boxed_expr) => match &**inner_boxed_expr {
-                        Expr::Ident(ident) => {
-                            if self
-                                .state
-                                .get_fusion_plugin_imports()
-                                .contains(ident.sym.as_ref())
-                            {
-                                debug!("withTranslations call matched");
-                                if let Some(first_arg) = inner_call_expr.args.get(0) {
-                                    match &*first_arg.expr {
-                                        Expr::Array(array_lit) => {
-                                            for elem in &array_lit.elems {
-                                                if let Some(ExprOrSpread { expr, .. }) = elem {
-                                                    if let Expr::Lit(Lit::Str(str_lit)) = &**expr {
-                                                        self.state.add_translation_id(
-                                                            str_lit.value.as_ref().to_owned(),
-                                                        );
-                                                    } else {
-                                                        HANDLER.with(|handler| {
-                                                            handler.err(error_msg);
-                                                        });
-                                                    }
-                                                }
+                Expr::Ident(ident) => {
+                    if self
+                        .state
+                        .get_fusion_plugin_imports()
+                        .contains(ident.sym.as_ref())
+                    {
+                        debug!("withTranslations call matched");
+                        if let Some(first_arg) = call_expr.args.get(0) {
+                            match &*first_arg.expr {
+                                Expr::Array(array_lit) => {
+                                    for elem in &array_lit.elems {
+                                        if let Some(ExprOrSpread { expr, .. }) = elem {
+                                            if let Expr::Lit(Lit::Str(str_lit)) = &**expr {
+                                                self.state.add_translation_id(
+                                                    str_lit.value.as_ref().to_owned(),
+                                                );
+                                            } else {
+                                                HANDLER.with(|handler| {
+                                                    handler.err(error_msg);
+                                                });
                                             }
                                         }
-                                        _ => HANDLER.with(|handler| {
-                                            handler.err(error_msg);
-                                        }),
                                     }
                                 }
+                                _ => HANDLER.with(|handler| {
+                                    handler.err(error_msg);
+                                }),
                             }
                         }
-                        _ => {}
-                    },
-                    _ => {}
-                },
+                    }
+                }
                 _ => {}
             },
             _ => {}


### PR DESCRIPTION
Reduce the depth of matching now that children are traversed correctly, which was preventing certain HOC usage from being detected correctly.